### PR TITLE
fix: Irish prefix not being limited to beginning of name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var knownPatronyms = /o'|mac|mc/i;
-var knownExceptions = /ng/i;
+var knownPatronyms = /^(o'|mac|mc)/i;
+var knownExceptions = /^ng/i;
 
 // Return string in title case
 function titleCase(input) {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "chai": "~2.2.0"
+  },
+  "devDependencies": {
+    "mocha": "^4.0.1"
   }
 }

--- a/test/test-formattr.js
+++ b/test/test-formattr.js
@@ -38,6 +38,7 @@ describe('Testing formatting library', function () {
         expect(formattr.formatName('{last}, {first} {m}', 'powers', 'austin', 'danger')).to.equal('Powers, Austin D.');
         expect(formattr.formatName('The name\'s {last}.  {first} {last}.', 'bond', 'james')).to.equal('The name\'s Bond.  James Bond.');
         expect(formattr.formatName('{first} {last}', 'simcelescu', 'dan')).to.equal('Dan Simcelescu');
+        expect(formattr.formatName('{first} {last}', 'mcdonald', 'ronald')).to.equal('Ronald McDonald');
         
         // Test error handling
         expect(formattr.formatName.bind(formattr, '{first} {middle} {last}', 'schwarzenegger', 'arnold')).to.throw(Error);

--- a/test/test-formattr.js
+++ b/test/test-formattr.js
@@ -37,7 +37,8 @@ describe('Testing formatting library', function () {
         expect(formattr.formatName('{first} {middle} {last}', 'barbarian', 'conan', 'the')).to.equal('Conan The Barbarian');
         expect(formattr.formatName('{last}, {first} {m}', 'powers', 'austin', 'danger')).to.equal('Powers, Austin D.');
         expect(formattr.formatName('The name\'s {last}.  {first} {last}.', 'bond', 'james')).to.equal('The name\'s Bond.  James Bond.');
-
+        expect(formattr.formatName('{first} {last}', 'simcelescu', 'dan')).to.equal('Dan Simcelescu');
+        
         // Test error handling
         expect(formattr.formatName.bind(formattr, '{first} {middle} {last}', 'schwarzenegger', 'arnold')).to.throw(Error);
         expect(formattr.formatName.bind(formattr, null, 'schwarzenegger', 'arnold', 'alois')).to.throw(Error);


### PR DESCRIPTION
Found a little bug.

There was a problem with names that had `mc` or `mac` within them but not at the beginning of the string resulting in garbled results (Simcelescu would be turned into McMelcescu)